### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/univie-ling/biblatex-univie-ling/univie-ling.bbx
+++ b/univie-ling/biblatex-univie-ling/univie-ling.bbx
@@ -563,8 +563,8 @@
 \DeclareFieldFormat{pages}{#1}     % no pp. prefix, took \mkpageprefix out [kvf]
 \DeclareFieldFormat{doi}{%
   \ifhyperref
-    {\href{http://dx.doi.org/#1}{\nolinkurl{http://dx.doi.org/#1}}}
-    {\nolinkurl{http://dx.doi.org/#1}}}
+    {\href{https://doi.org/#1}{\nolinkurl{https://doi.org/#1}}}
+    {\nolinkurl{https://doi.org/#1}}}
 \DeclareFieldFormat{url}{\url{#1}}
 
 \DeclareFieldFormat{volume:unified:proc-as-article}{#1}


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)